### PR TITLE
use curl instead of wget so OSX is supported, fix #139

### DIFF
--- a/bin/sequenceserver
+++ b/bin/sequenceserver
@@ -250,7 +250,9 @@ ERR
                 end
 
           archive = File.join('/tmp', File.basename(url))
-          system "wget -c #{url} -O #{archive} && mkdir -p ~/.sequenceserver" \
+          # -ip4 is required  to avoid this curl bug http://sourceforge.net/p/curl/bugs/1424/?limit=25
+          # see also https://github.com/yannickwurm/sequenceserver/issues/139
+          system "curl -ip4 -C - #{url} -o #{archive} && mkdir -p ~/.sequenceserver" \
             "&& tar xvf #{archive} -C ~/.sequenceserver"
           unless $CHILD_STATUS.success?
             puts 'Failed to install BLAST+.'


### PR DESCRIPTION
Only concern I have for this is the -ip4 flag. There's currently a bug in curl that means this is required in some networks - see #139 for details.