### PR TITLE
Show the GET/POST requests made by the server only in the development environment

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -55,7 +55,7 @@ module SequenceServer
       server = Thin::Server.new(config[:host],
                                 config[:port],
                                 :signals => false) do
-        use Rack::CommonLogger
+        use Rack::CommonLogger if SequenceServer.environment == 'development'
         run SequenceServer
       end
       server.silent = true

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -55,7 +55,7 @@ module SequenceServer
       server = Thin::Server.new(config[:host],
                                 config[:port],
                                 :signals => false) do
-        use Rack::CommonLogger if SequenceServer.environment == 'development'
+        use Rack::CommonLogger if SequenceServer.verbose?
         run SequenceServer
       end
       server.silent = true


### PR DESCRIPTION
The Rack::CommonLogger shows all the GET/ POST etc. requests made by the server. Most normal people do not care about this information...

Thus, I think it would be best to only show this information when in the development environment and not in the production environment (i.e. only when using the `-D` command line argument)

Any thoughts?

It would also make it easier for ('new to bash') users to see how to close the local server...

Signed-off-by: IsmailM <ismail.moghul@gmail.com>