### PR TITLE
Change the host default to localhost

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -150,7 +150,7 @@ module SequenceServer
       raise NUM_THREADS_INCORRECT
     end
 
-    # Check and warn user if host is 0.0.0.0 (default).
+    # Check and warn user if host is 0.0.0.0.
     def check_host
       # rubocop:disable Style/GuardClause
       if config[:host] == '0.0.0.0'

--- a/lib/sequenceserver/config.rb
+++ b/lib/sequenceserver/config.rb
@@ -84,7 +84,7 @@ module SequenceServer
       {
         :num_threads  => 1,
         :port         => 4567,
-        :host         => '0.0.0.0'
+        :host         => 'localhost'
       }
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -23,7 +23,7 @@ module SequenceServer
     it 'has reasonable defaults' do
       config = Config.new
       config[:num_threads].should eq 1
-      config[:host].should eq '0.0.0.0'
+      config[:host].should eq 'localhost'
       config[:port].should eq 4567
       config.config_file.should eq File.expand_path('~/.sequenceserver.conf')
     end


### PR DESCRIPTION
As requested in #158...

@yeban:
* Do you have a preference between `http://localhost:4567` & `http://127.0.0.1:4556`
* Secondly, should I remove the `check_host` [method](https://github.com/yannickwurm/sequenceserver/blob/master/lib/sequenceserver.rb#L153) completely or is still worthwhile checking if the host is `http://0.0.0.0`?

NB: you may need to clear the `host` value in your config file in order to use the new default.