### PR TITLE
open localhost if host is '127.0.0.1' or '0.0.0.0'

### DIFF
--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -185,11 +185,9 @@ module SequenceServer
     end
 
     def server_url
-      if config[:host] == '127.0.0.1' || config[:host] == '0.0.0.0'
-        "http://localhost:#{config[:port]}"
-      else
-        "http://#{config[:host]}:#{config[:port]}"
-      end
+      host = config[:host]
+      host = 'localhost' if host == '127.0.0.1' || host == '0.0.0.0'
+      "http://#{host}:#{config[:port]}"
     end
 
     def open_default_browser(url)

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -51,7 +51,6 @@ module SequenceServer
     # Run SequenceServer as a self-hosted server using Thin webserver.
     def run
       check_host
-      url = "http://#{config[:host]}:#{config[:port]}"
       server = Thin::Server.new(config[:host],
                                 config[:port],
                                 :signals => false) do
@@ -61,9 +60,9 @@ module SequenceServer
       server.silent = true
       server.backend.start do
         puts '** SequenceServer is ready.'
-        puts "   Go to #{url} in your browser and start BLASTing!"
+        puts "   Go to #{server_url} in your browser and start BLASTing!"
         puts '   Press CTRL+C to quit.'
-        open_default_browser(url)
+        open_default_browser(server_url)
         [:INT, :TERM].each do |sig|
           trap sig do
             server.stop!
@@ -77,7 +76,7 @@ module SequenceServer
       end
     rescue
       puts '** Oops! There was an error.'
-      puts "   Is SequenceServer already accessible at #{url}?"
+      puts "   Is SequenceServer already accessible at #{server_url}?"
       puts '   Try running SequenceServer on another port, like so:'
       puts
       puts '       sequenceserver -p 4570.'
@@ -183,6 +182,14 @@ module SequenceServer
       version = `blastdbcmd -version`.split[1]
       fail BLAST_NOT_EXECUTABLE if !$CHILD_STATUS.success? || version.empty?
       fail BLAST_NOT_COMPATIBLE, version unless version >= MINIMUM_BLAST_VERSION
+    end
+
+    def server_url
+      if config[:host] == '127.0.0.1' || config[:host] == '0.0.0.0'
+        "http://localhost:#{config[:port]}"
+      else
+        "http://#{config[:host]}:#{config[:port]}"
+      end
     end
 
     def open_default_browser(url)

--- a/lib/sequenceserver.rb
+++ b/lib/sequenceserver.rb
@@ -62,7 +62,7 @@ module SequenceServer
         puts '** SequenceServer is ready.'
         puts "   Go to #{server_url} in your browser and start BLASTing!"
         puts '   Press CTRL+C to quit.'
-        open_default_browser(server_url)
+        open_in_browser(server_url)
         [:INT, :TERM].each do |sig|
           trap sig do
             server.stop!
@@ -190,12 +190,12 @@ module SequenceServer
       "http://#{host}:#{config[:port]}"
     end
 
-    def open_default_browser(url)
+    def open_in_browser(server_url)
       return if using_ssh? || verbose?
       if RUBY_PLATFORM =~ /linux/ && xdg?
-        `xdg-open #{url}`
+        `xdg-open #{server_url}`
       elsif RUBY_PLATFORM =~ /darwin/
-        `open #{url}`
+        `open #{server_url}`
       end
     end
 


### PR DESCRIPTION
In response to #158...

SS should now show `localhost` in case the host is one of the follow: `localhost`, `127.0.0.1`, or `0.0.0.0`. 

Nevertheless, the Thin Server will still be opened at the configured host.

