### PR TITLE
update the `--host` shorthand from `-h` to `-H`

### DIFF
--- a/index.html
+++ b/index.html
@@ -678,7 +678,7 @@
                   </tr>
                   <tr>
                     <td>
-                      -h=host
+                      -H=host
                     </td>
                     <td>
                       Host to run SequenceServer on<sup>*</sup>


### PR DESCRIPTION
#164 

Update the website to reflect the change of the `-h, --host` command line argument to `-H, --host`.